### PR TITLE
fix(docker-compose): Cassandra service automatic exit 

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,6 +63,17 @@ services:
       - "9042:9042"
     volumes:
       - cassandra-data:/var/lib/cassandra
+    environment:
+      - MAX_HEAP_SIZE=512M
+      - HEAP_NEWSIZE=100M
+      - JVM_OPTS=-Xms256m -Xmx512m
+    deploy:
+      resources:
+        limits:
+          memory: 1.5G
+        reservations:
+          memory: 1G
+    restart: unless-stopped
     healthcheck:
       test: ["CMD", "cqlsh", "-e", "describe keyspaces"]
       interval: 10s


### PR DESCRIPTION
### Summary

This pull request addresses an issue where the Cassandra service in the Docker Compose setup would automatically exit. The changes introduce specific JVM memory configurations, define resource limits and reservations for the Cassandra container, and implement an automatic restart policy. These modifications aim to enhance the stability and reliability of the Cassandra service by preventing unexpected exits due to resource constraints and ensuring automatic recovery.

### Changes Introduced

* **Cassandra JVM Memory Configuration**: The Cassandra service in `docker-compose.yml` now includes environment variables (`MAX_HEAP_SIZE`, `HEAP_NEWSIZE`, `JVM_OPTS`) to explicitly configure its JVM heap memory, aiming to prevent out-of-memory issues.
* **Docker Compose Resource Allocation**: Resource limits and reservations have been added to the Cassandra service's `deploy` section, allocating 1GB of memory and limiting it to 1.5GB, which helps in stable resource allocation within the Docker environment.
* **Service Restart Policy**: A `restart: unless-stopped` policy has been applied to the Cassandra service, ensuring that the container automatically restarts if it crashes or exits unexpectedly, improving its resilience.
